### PR TITLE
Improve compatibility with the Catppuccin theme

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -304,37 +304,37 @@
 	color: var(--pf2e-error-highlight);
 }
 
-mark.pf2e-statblock-trait-normal, span.pf2e-statblock-trait-normal
-{
+.pf2e-statblock mark.pf2e-statblock-trait-normal,
+.pf2e-statblock span.pf2e-statblock-trait-normal {
 	background: var(--pf2e-normal-trait);
 }
 
-mark.pf2e-statblock-trait-size, span.pf2e-statblock-trait-size
-{
+.pf2e-statblock mark.pf2e-statblock-trait-size,
+.pf2e-statblock span.pf2e-statblock-trait-size {
 	background: var(--pf2e-size-trait);
 }
 
-mark.pf2e-statblock-trait-alignment, span.pf2e-statblock-trait-alignment
-{
+.pf2e-statblock mark.pf2e-statblock-trait-alignment,
+.pf2e-statblock span.pf2e-statblock-trait-alignment {
 	background: var(--pf2e-alignment-trait);
 }
 
-mark.pf2e-statblock-trait-settlement, span.pf2e-statblock-trait-settlement
-{
+.pf2e-statblock mark.pf2e-statblock-trait-settlement,
+.pf2e-statblock span.pf2e-statblock-trait-settlement {
 	background: var(--pf2e-settlement-trait);
 }
 
-mark.pf2e-statblock-trait-uncommon, span.pf2e-statblock-trait-uncommon
-{
+.pf2e-statblock mark.pf2e-statblock-trait-uncommon,
+.pf2e-statblock span.pf2e-statblock-trait-uncommon {
 	background: var(--pf2e-uncommon-trait);
 }
 
-mark.pf2e-statblock-trait-rare, span.pf2e-statblock-trait-rare
-{
+.pf2e-statblock mark.pf2e-statblock-trait-rare,
+.pf2e-statblock span.pf2e-statblock-trait-rare {
 	background: var(--pf2e-rare-trait);
 }
 
-mark.pf2e-statblock-trait-unique, span.pf2e-statblock-trait-unique
-{
+.pf2e-statblock mark.pf2e-statblock-trait-unique,
+.pf2e-statblock span.pf2e-statblock-trait-unique {
 	background: var(--pf2e-unique-trait);
 }


### PR DESCRIPTION
This PR addresses a styling conflict between this plugin's trait styles and the popular [Catppuccin Obsidian theme](https://github.com/catppuccin/obsidian). The issue occurs because both the plugin and the theme target `mark` elements with the same CSS specificity, causing the theme's styles to override the plugin in these cases.

### What is CSS specificity?

[CSS specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Specificity) is the algorithm browsers use to determine which CSS rule applies when multiple rules target the same element and attempt to set the same property. It's calculated based on the types of selectors used:

- Type selectors (like `mark`) have the lowest specificity (0,0,1)
- Class selectors (like `.pf2e-statblock-trait-normal`) have medium specificity (0,1,0)
- ID selectors have the highest specificity (1,0,0)

When selectors have equal specificity, the last one defined wins. This is why theme styles in Obsidian (loaded after plugin styles) can override plugin styling.

### The Problem

Both this plugin and the Catpucchin Obsidian theme have CSS rules with the same (0,1,1) specificity that set the `background-color` property on elements such as `mark.pf2e-statblock-trait-size`:

- https://github.com/pixley/pf2e-statblock-for-obsidian/blob/main/styles.css#L307
- https://github.com/catppuccin/obsidian/blob/main/scss/base/_typography.scss#L134

And due to Obsidian's loading order, the theme's CSS rule is being applied last, resulting in traits that are impossible to read:

<img width="1659" alt="Screenshot 2025-04-08 at 20 38 07" src="https://github.com/user-attachments/assets/e9ce2c03-cc97-452d-a733-eb3352157011" />

<img width="1659" alt="Screenshot 2025-04-08 at 20 38 10" src="https://github.com/user-attachments/assets/22604ce1-aba8-42b3-84f1-2ac0b9f1fdbe" />

### The Solution

I've increased the specificity of the trait selectors by prefixing them with the `.pf2e-statblock` class, changing the specificity from (0,1,1) to (0,2,1). This technique is [already used](https://github.com/pixley/pf2e-statblock-for-obsidian/blob/main/styles.css#L83) throughout the plugin's `style.css` stylesheet, and is a standard approach for ensuring plugin styles take precedence over theme styles.

For example, changing:

```css
mark.pf2e-statblock-trait-normal, 
span.pf2e-statblock-trait-normal {
  background: var(--pf2e-normal-trait);
}
```

to:

```css
.pf2e-statblock mark.pf2e-statblock-trait-normal, 
.pf2e-statblock span.pf2e-statblock-trait-normal {
  background: var(--pf2e-normal-trait);
}
```

results in:

<img width="1659" alt="Screenshot 2025-04-08 at 20 40 06" src="https://github.com/user-attachments/assets/d059498a-6867-42fe-9b16-4c205bab6943" />

NOTE: I've applied this change to all trait style selectors to ensure consistent behavior and future-proof against similar conflicts with other themes.