### PR TITLE
Fix indentation for action-icon subentries

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -181,6 +181,11 @@ function applyIndentation(statblockElement: HTMLElement, rootElement: HTMLElemen
 						// with negative indentation
 						currentSubPara.classList.add("pf2e-statblock-subentry");
 						console.debug("Start-of-line is bold.");
+					} else if (childNode instanceof Element && childElement.tagName === "CODE" &&
+						childElement.classList.contains("action-icon")) {
+						// Lines that start with an action icon use the same hanging indentation as bold subentries.
+						currentSubPara.classList.add("pf2e-statblock-subentry");
+						console.debug("Start-of-line is an action icon.");
 					} else if (currentSubPara.previousElementSibling != null &&
 						currentSubPara.previousElementSibling.tagName === "P" &&
 						!currentSubPara.previousElementSibling.classList.contains("pf2e-statblock-subentry") &&


### PR DESCRIPTION
Thanks again for merging #18. I ran into another small formatting edge case while testing variable-action abilities.

While importing the [Beiran Frosthunt](https://2e.aonprd.com/Monsters.aspx?ID=3809) creature, I noticed an odd indentation issue in **Icy Japes**. The ability has separate damage lines for its one-, two-, and three-action versions. In the rendered statblock, those lines gradually stepped farther to the right instead of lining up beneath the ability.

<img width="863" height="552" alt="Screenshot 2026-08-07 at 20 18 17" src="https://github.com/user-attachments/assets/7bf473c8-08a1-497b-a64c-aacd4a8ca7c0" />

The lines start with action icons, rather than bold labels like **Success** or **Failure**. The renderer was treating the later action-icon lines as paragraph continuations instead of separate sibling entries.

This change treats a line beginning with an action icon as a subentry. The one-, two-, and three-action damage lines now stay aligned, while the existing bold-label behavior remains unchanged.

<img width="865" height="551" alt="Screenshot 2026-08-07 at 20 17 16" src="https://github.com/user-attachments/assets/4ad5cb2e-4f17-424a-b446-7be9830db5dc" />

## Testing

- Ran `npm run build`
- Rendered a variable-action ability with one-, two-, and three-action effect lines in Obsidian
- Confirmed the action-icon lines align as sibling subentries
- Confirmed bold-led subentries continue through the existing `STRONG` branch
